### PR TITLE
ci: enforce squash-only merge policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Enforce squash-only merge policy (no merge commits in PR branch)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          MERGE_BASE=$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})
+          COUNT=$(git rev-list --count --merges "$MERGE_BASE..${{ github.event.pull_request.head.sha }}")
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::PR branch contains $COUNT merge commit(s). Rebase on base branch; use Squash and merge only."
+            exit 1
+          fi
+          echo "No merge commits in PR branch; squash merge policy OK."
       - name: Verify commit signatures (GitHub verification API)
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -87,9 +98,9 @@ jobs:
         run: |
           V=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
           if ! echo "$V" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then echo "::error::Cargo.toml version must be valid SemVer (X.Y.Z)"; exit 1; fi
-      - run: cargo fmt --check
-      - run: cargo clippy -- -D warnings
-      - run: cargo test
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test --all
       - name: Supply chain (cargo-deny)
         run: |
           cargo install cargo-deny --locked


### PR DESCRIPTION
This PR enforces squash-only merge strategy:  - Fails CI if PR branch contains merge commits - Requires rebase before merging - Ensures clean linear history - Compatible with repository settings (squash-only enabled)  No business logic changes.  Made with [Cursor](https://cursor.com) 

Governance backfill: Closes #10.